### PR TITLE
dagmc cmakified from the top

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,9 +50,13 @@ include_directories(${SCIMAKE_DIR}/include)
 set(DAGMC_VERSION "${VERSION}-${PROJECT_REV}")
 install(CODE "message(STATUS \"Installing into \${CMAKE_INSTALL_PREFIX}.\")")
 
+# JRC: I am removing this, as a project should make this decision, not
+# scimake.  It goes into SciInit in any case.
+if (FALSE)
 if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.4")
 # Only works on gcc > 4.4
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-type")
+endif()
 endif()
 
 ######################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,15 @@ cmake_minimum_required(VERSION 2.8)
 #
 ######################################################################
 
-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/scimake)
-  message(STATUS "${CMAKE_CURRENT_SOURCE_DIR}/scimake found.  Update needed?")
+if (EXISTS ${PROJECT_SOURCE_DIR}/scimake)
+  message(STATUS "${PROJECT_SOURCE_DIR}/scimake found.  Update needed?")
 else ()
   execute_process(COMMAND svn co https://svn.code.sf.net/p/scimake/code/trunk scimake
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   )
+endif ()
+if (NOT EXISTS ${PROJECT_SOURCE_DIR}/scimake)
+  message(FATAL_ERROR "scimake not found.")
 endif ()
 
 ######################################################################
@@ -40,17 +43,15 @@ endif ()
 #
 ######################################################################
 
-if (FALSE)
 set(NOFORTRAN TRUE)
 set(NO_CONFIG_H TRUE)
 include(${PROJECT_SOURCE_DIR}/scimake/SciInit.cmake)
 include_directories(${SCIMAKE_DIR}/include)
-set(CTK_VERSION "${VERSION}-${PROJECT_REV}")
+set(DAGMC_VERSION "${VERSION}-${PROJECT_REV}")
 install(CODE "message(STATUS \"Installing into \${CMAKE_INSTALL_PREFIX}.\")")
-include(${PROJECT_SOURCE_DIR}/txcmake/TxInit.cmake)
 
 if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.4")
-  # Only works on gcc > 4.4
+# Only works on gcc > 4.4
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-type")
 endif()
 
@@ -81,105 +82,34 @@ endif ()
 # Add the automatically determined parts of the RPATH that
 # point to directories outside the build tree to the install RPATH
 
-######################################################################
-#
-# Find packages and set includes
-# For libraries that are used for ALL builds
-#
-######################################################################
-
-# To find the right installations
-set(USE_CC4PY_LIBS TRUE)
-
-# Find Qt
-set(QT_REQUIRED_LIBRARIES
-  QtCore QtGui QtOpenGL QtXml QtXmlPatterns QtNetwork QtWebKit
-)
-find_package(SciQt4 COMPONENTS ${QT_REQUIRED_LIBRARIES} REQUIRED)
-include(SciFindQtPkg)
-# SciFindQtPkg(PACKAGE Qt3D HEADERS qglview.h LIBRARIES Qt3D)
-find_package(SciPythonLibs REQUIRED)
-
-######################################################################
-#
-# Find visit related packages
-#
-######################################################################
-
-SciGetInstSubdirs(visit4ctk instDirs)
-set(VisIt_INSTALL_DIRS ${instDirs})
-find_package(SciVisIt REQUIRED)
-
-set(Vtk_INSTALL_DIRS vtk4ctk-cc4py vtk4ctk-sersh vtk4ctk)
-find_package(SciVtk REQUIRED)
-
-# Add VTK headers to the build
-include_directories(${Vtk_INCLUDE_DIRS})
-
 ###################################################
 #
-# For remote operations
+# Common packages
 #
 ###################################################
 
-#if (ENABLE_REMOTE)
-# Make sure we always find the shared installations.
-find_package(TxSsh  REQUIRED)
-find_package(SciLibssh REQUIRED)
-#endif ()
-
-find_package(TxGml)
-if (TXGML_FOUND)
-  add_definitions(${TxGml_DEFINITIONS})
-  find_package(SciOce COMPONENTS XdeIges XdeStep Xde Mesh Step Stl REQUIRED)
-  include(SciFindQtPkg)
-  SciFindQtPkg(PACKAGE Qt3D HEADERS qglview.h LIBRARIES Qt3D)
-  find_package(TxUtils REQUIRED)
-  include_directories(
-    ${TxGml_INCLUDE_DIRS}
-    ${Oce_INCLUDE_DIRS}
-    ${QT_QT3D_INCLUDE_DIRS}
-    ${TxUtils_INCLUDE_DIRS}
-  )
-endif ()
-
-# Licensing
-include(${PROJECT_SOURCE_DIR}/txcmake/TxEnableSecurity.cmake)
-
-###################################################
-#
-# Boost and compression
-#
-###################################################
-
-# Boost needed on windows, zlib is not
-find_package(SciBoost REQUIRED thread chrono system)
-find_package(SciSz)
-find_package(SciZ REQUIRED)
-
-###################################################
-#
-# For basic capabilities
-#
-###################################################
-
-find_package(SciTxBase REQUIRED)
 find_package(SciHdf5 REQUIRED)
+find_package(SciBoost REQUIRED thread chrono system)
 
 ###################################################
 #
-# Code subdirectories that depend on finding something.
+# Packages specific to geometry and monte carlo
 #
 ###################################################
 
-message(STATUS "Adding src subdirectory.")
-add_subdirectory(src)
-message(STATUS "Adding ctkqt subdirectory.")
-add_subdirectory(ctkqt)
-message(STATUS "Adding resources subdirectory.")
-add_subdirectory(resources)
-message(STATUS "Adding ctkscripts subdirectory.")
-add_subdirectory(ctkscripts)
+find_package(SciMoab REQUIRED)
+find_package(SciGeant4 REQUIRED)
+
+###################################################
+#
+# Add subdirectories
+#
+###################################################
+
+message("")
+set(SCI_INDENT "")
+message(STATUS "Adding Geant4 subdir.")
+add_subdirectory(Geant4)
 
 ###################################################
 #
@@ -189,10 +119,9 @@ add_subdirectory(ctkscripts)
 
 find_package(SciDoxygen)
 if (${DOXYGEN_FOUND})
-  message(STATUS "Adding ctkdevdocs subdirectory.")
-  add_subdirectory(ctkdevdocs)
+  message(STATUS "Doxygen found.")
 else ()
-  message(WARNING "Doxygen not found. Not adding ctkdevdocs sub directory")
+  message(WARNING "Doxygen not found.")
 endif ()
 
 ###################################################
@@ -212,38 +141,17 @@ enable_testing()
 #
 ######################################################################
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CtkConfig.h.in
-  ${CMAKE_CURRENT_BINARY_DIR}/CtkConfig.h)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CtkVersion.h.in
-  ${CMAKE_CURRENT_BINARY_DIR}/CtkVersion.h)
-
-######################################################################
-#
-# Installations at this level
-#
-######################################################################
-
-if (EXISTS ${PROJECT_SOURCE_DIR}/svninfo.txt)
-  install(FILES svninfo.txt DESTINATION share)
-  message(STATUS "--- svninfo.txt found. Will be installed")
-else ()
-  message(STATUS "--- svninfo.txt NOT found. Skipping install")
-endif ()
-
+if (FALSE)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DagMcConfig.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/DagMcConfig.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DagMcVersion.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/DagMcVersion.h)
 install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/CMakeCache.txt
-  DESTINATION share
-)
-
-install(FILES
-  ${CMAKE_CURRENT_BINARY_DIR}/CtkVersion.h
-  ${CMAKE_CURRENT_BINARY_DIR}/CtkConfig.h
-  ${CMAKE_CURRENT_SOURCE_DIR}/CtkConfig.h.in  # For configuration by composers
+  ${CMAKE_CURRENT_BINARY_DIR}/DagMcVersion.h
+  ${CMAKE_CURRENT_BINARY_DIR}/DagMcConfig.h
   DESTINATION include
 )
-
-# Install the entire resources directory
-install(DIRECTORY resources DESTINATION . PATTERN ".svn" EXCLUDE)
+endif ()
 
 ######################################################################
 #
@@ -256,16 +164,14 @@ set(CPACK_PACKAGE_VERSION_MAJOR ${VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${VERSION_PATCH}-r${PROJECT_REV})
 
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Tech-X ComposerToolkit Library")
-set(CPACK_PACKAGE_VENDOR "Tech-X Corporation")
-set(CPACK_PACKAGE_DESCRIPTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/README.txt)
-set(CPACK_SOURCE_PACKAGE_FILE_NAME "ctk-${VERSION}-r${PROJECT_REV}"
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "DagMc Library")
+set(CPACK_PACKAGE_VENDOR "No Vendor")
+set(CPACK_PACKAGE_DESCRIPTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/README.rst)
+set(CPACK_SOURCE_PACKAGE_FILE_NAME "dagmc-${VERSION}-r${PROJECT_REV}"
     CACHE INTERNAL "tarball basename")
 set(CPACK_SOURCE_GENERATOR TGZ)
 set(CPACK_SOURCE_IGNORE_FILES
 "/CVS/;/.svn/;.swp$;.#;/#;/build/;/serial/;/parallel/;~$;/autom4te.cache/;/.config;preconfig.out")
 set(CPACK_GENERATOR TGZ)
 include(CPack)
-
-endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,271 @@
+######################################################################
+#
+# CMakeLists.txt for Geant4 of dagmc
+#
+# $Id: CMakeLists.txt 6426 2014-02-21 17:56:17Z cary $
+#
+# Copyright &copy; 2002-2012, University of Colorado and Tech-X Corporation
+# See LICENSE file for conditions of use.
+#
+######################################################################
+
+# Project information
+project(dagmcg4)
+set(VERSION_MAJOR "0")
+set(VERSION_MINOR "1")
+set(VERSION_PATCH "0")
+set(VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
+
+# Required version
+cmake_minimum_required(VERSION 2.8)
+
+######################################################################
+#
+# Grab the scimake repo
+#
+######################################################################
+
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/scimake)
+  message(STATUS "${CMAKE_CURRENT_SOURCE_DIR}/scimake found.  Update needed?")
+else ()
+  execute_process(COMMAND svn co https://svn.code.sf.net/p/scimake/code/trunk scimake
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+endif ()
+
+######################################################################
+#
+# Usual initialization stuff, sciInit includes txfindpackage and
+# takes care of MPI
+#
+######################################################################
+
+if (FALSE)
+set(NOFORTRAN TRUE)
+set(NO_CONFIG_H TRUE)
+include(${PROJECT_SOURCE_DIR}/scimake/SciInit.cmake)
+include_directories(${SCIMAKE_DIR}/include)
+set(CTK_VERSION "${VERSION}-${PROJECT_REV}")
+install(CODE "message(STATUS \"Installing into \${CMAKE_INSTALL_PREFIX}.\")")
+include(${PROJECT_SOURCE_DIR}/txcmake/TxInit.cmake)
+
+if(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.4")
+  # Only works on gcc > 4.4
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-type")
+endif()
+
+######################################################################
+#
+# Always use rpath to greatest extent.
+# See: http://www.itk.org/Wiki/CMake_RPATH_handling
+# Add -DCMAKE_SKIP_RPATH:BOOL=TRUE to prevent any rpath handling
+#
+######################################################################
+
+# SET(CMAKE_SKIP_BUILD_RPATH FALSE)
+# Use, i.e. don't skip the full RPATH for the build tree
+# Not needed since we build static libs
+
+# SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+# When building, don't link with the install RPATH at build,
+# but add later on when installing.
+# Not needed since we build static libs
+
+# SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+# The RPATH to be used when installing
+# Not needed since we build static libs
+
+if (NOT DEFINED CMAKE_INSTALL_RPATH_USE_LINK_PATH)
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+endif ()
+# Add the automatically determined parts of the RPATH that
+# point to directories outside the build tree to the install RPATH
+
+######################################################################
+#
+# Find packages and set includes
+# For libraries that are used for ALL builds
+#
+######################################################################
+
+# To find the right installations
+set(USE_CC4PY_LIBS TRUE)
+
+# Find Qt
+set(QT_REQUIRED_LIBRARIES
+  QtCore QtGui QtOpenGL QtXml QtXmlPatterns QtNetwork QtWebKit
+)
+find_package(SciQt4 COMPONENTS ${QT_REQUIRED_LIBRARIES} REQUIRED)
+include(SciFindQtPkg)
+# SciFindQtPkg(PACKAGE Qt3D HEADERS qglview.h LIBRARIES Qt3D)
+find_package(SciPythonLibs REQUIRED)
+
+######################################################################
+#
+# Find visit related packages
+#
+######################################################################
+
+SciGetInstSubdirs(visit4ctk instDirs)
+set(VisIt_INSTALL_DIRS ${instDirs})
+find_package(SciVisIt REQUIRED)
+
+set(Vtk_INSTALL_DIRS vtk4ctk-cc4py vtk4ctk-sersh vtk4ctk)
+find_package(SciVtk REQUIRED)
+
+# Add VTK headers to the build
+include_directories(${Vtk_INCLUDE_DIRS})
+
+###################################################
+#
+# For remote operations
+#
+###################################################
+
+#if (ENABLE_REMOTE)
+# Make sure we always find the shared installations.
+find_package(TxSsh  REQUIRED)
+find_package(SciLibssh REQUIRED)
+#endif ()
+
+find_package(TxGml)
+if (TXGML_FOUND)
+  add_definitions(${TxGml_DEFINITIONS})
+  find_package(SciOce COMPONENTS XdeIges XdeStep Xde Mesh Step Stl REQUIRED)
+  include(SciFindQtPkg)
+  SciFindQtPkg(PACKAGE Qt3D HEADERS qglview.h LIBRARIES Qt3D)
+  find_package(TxUtils REQUIRED)
+  include_directories(
+    ${TxGml_INCLUDE_DIRS}
+    ${Oce_INCLUDE_DIRS}
+    ${QT_QT3D_INCLUDE_DIRS}
+    ${TxUtils_INCLUDE_DIRS}
+  )
+endif ()
+
+# Licensing
+include(${PROJECT_SOURCE_DIR}/txcmake/TxEnableSecurity.cmake)
+
+###################################################
+#
+# Boost and compression
+#
+###################################################
+
+# Boost needed on windows, zlib is not
+find_package(SciBoost REQUIRED thread chrono system)
+find_package(SciSz)
+find_package(SciZ REQUIRED)
+
+###################################################
+#
+# For basic capabilities
+#
+###################################################
+
+find_package(SciTxBase REQUIRED)
+find_package(SciHdf5 REQUIRED)
+
+###################################################
+#
+# Code subdirectories that depend on finding something.
+#
+###################################################
+
+message(STATUS "Adding src subdirectory.")
+add_subdirectory(src)
+message(STATUS "Adding ctkqt subdirectory.")
+add_subdirectory(ctkqt)
+message(STATUS "Adding resources subdirectory.")
+add_subdirectory(resources)
+message(STATUS "Adding ctkscripts subdirectory.")
+add_subdirectory(ctkscripts)
+
+###################################################
+#
+# Documentation
+#
+###################################################
+
+find_package(SciDoxygen)
+if (${DOXYGEN_FOUND})
+  message(STATUS "Adding ctkdevdocs subdirectory.")
+  add_subdirectory(ctkdevdocs)
+else ()
+  message(WARNING "Doxygen not found. Not adding ctkdevdocs sub directory")
+endif ()
+
+###################################################
+#
+# Testing
+#
+###################################################
+
+# Enable tests
+include(CTestConfig.cmake)
+include(CTest)
+enable_testing()
+
+######################################################################
+#
+# Configure files
+#
+######################################################################
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CtkConfig.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/CtkConfig.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CtkVersion.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/CtkVersion.h)
+
+######################################################################
+#
+# Installations at this level
+#
+######################################################################
+
+if (EXISTS ${PROJECT_SOURCE_DIR}/svninfo.txt)
+  install(FILES svninfo.txt DESTINATION share)
+  message(STATUS "--- svninfo.txt found. Will be installed")
+else ()
+  message(STATUS "--- svninfo.txt NOT found. Skipping install")
+endif ()
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/CMakeCache.txt
+  DESTINATION share
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/CtkVersion.h
+  ${CMAKE_CURRENT_BINARY_DIR}/CtkConfig.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/CtkConfig.h.in  # For configuration by composers
+  DESTINATION include
+)
+
+# Install the entire resources directory
+install(DIRECTORY resources DESTINATION . PATTERN ".svn" EXCLUDE)
+
+######################################################################
+#
+# Packaging
+#
+######################################################################
+
+# CPack version numbers for release tarball name.
+set(CPACK_PACKAGE_VERSION_MAJOR ${VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MINOR ${VERSION_MINOR})
+set(CPACK_PACKAGE_VERSION_PATCH ${VERSION_PATCH}-r${PROJECT_REV})
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Tech-X ComposerToolkit Library")
+set(CPACK_PACKAGE_VENDOR "Tech-X Corporation")
+set(CPACK_PACKAGE_DESCRIPTION_FILE ${CMAKE_CURRENT_SOURCE_DIR}/README.txt)
+set(CPACK_SOURCE_PACKAGE_FILE_NAME "ctk-${VERSION}-r${PROJECT_REV}"
+    CACHE INTERNAL "tarball basename")
+set(CPACK_SOURCE_GENERATOR TGZ)
+set(CPACK_SOURCE_IGNORE_FILES
+"/CVS/;/.svn/;.swp$;.#;/#;/build/;/serial/;/parallel/;~$;/autom4te.cache/;/.config;preconfig.out")
+set(CPACK_GENERATOR TGZ)
+include(CPack)
+
+endif ()
+

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,21 @@
+######################################################################
+#
+# CTestConfig: Set variables for testing.
+#
+# $Id: CTestConfig.cmake 22535 2014-02-11 23:21:43Z veitzer $
+#
+# Copyright 2010-2013 Tech-X Corporation.
+# Arbitrary redistribution allowed provided this copyright remains.
+#
+# See LICENSE file (EclipseLicense.txt) for conditions of use.
+#
+######################################################################
+
+#
+# enable_testing() and include(CTest) must be called after this is included.
+#
+# This is actually set by Bilder
+if (CTEST_DROP_SITE)
+  include(${PROJECT_SOURCE_DIR}/scimake/SciTestConfig.cmake)
+endif ()
+

--- a/Geant4/CMakeLists.txt
+++ b/Geant4/CMakeLists.txt
@@ -7,5 +7,7 @@
 ######################################################################
 
 # Add in directories in layering order, lowest to highest
-# add_subdirectory()
+set(SCI_INDENT "${SCI_INDENT}  ")
+message(STATUS "${SCI_INDENT}Adding dagsolid subdir.")
+add_subdirectory(dagsolid)
 

--- a/Geant4/CMakeLists.txt
+++ b/Geant4/CMakeLists.txt
@@ -1,0 +1,11 @@
+######################################################################
+#
+# CMakeLists.txt for dagmc Geant4
+#
+# $Id: CMakeLists.txt 6346 2014-01-27 03:33:21Z cary $
+#
+######################################################################
+
+# Add in directories in layering order, lowest to highest
+# add_subdirectory()
+

--- a/Geant4/dagsolid/CMakeLists.txt
+++ b/Geant4/dagsolid/CMakeLists.txt
@@ -1,10 +1,23 @@
-PROJECT (DagSolid)
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6.4)
+######################################################################
+#
+# CMakeLists.txt for dagmc/Geant4/dagsolid
+#
+# $Id: CMakeLists.txt 6346 2014-01-27 03:33:21Z cary $
+#
+######################################################################
+
+if (NOT DEFINED CMAKE_PROJECT_NAME)
+  PROJECT(DagSolid)
+  CMAKE_MINIMUM_REQUIRED(VERSION 2.6.4)
+endif ()
 
 # disable threading
 add_definitions(-DGTEST_HAS_PTHREAD=0)
 
 # Run cmake on the CMakeLists.txt in these subdirectories
+set(SCI_INDENT "${SCI_INDENT}  ")
+message(STATUS "${SCI_INDENT}Adding src subdir.")
 ADD_SUBDIRECTORY(src)
-ADD_SUBDIRECTORY(test)
+# message(STATUS "Adding test subdir.")
+# ADD_SUBDIRECTORY(test)
 

--- a/Geant4/dagsolid/src/CMakeLists.txt
+++ b/Geant4/dagsolid/src/CMakeLists.txt
@@ -1,25 +1,50 @@
-cmake_minimum_required(VERSION 2.6.4)
+######################################################################
+#
+# CMakeLists.txt for dagmc/Geant4/dagsolid/src
+#
+# $Id: CMakeLists.txt 6346 2014-01-27 03:33:21Z cary $
+#
+######################################################################
 
+if (NOT DEFINED CMAKE_PROJECT_NAME)
+# Legacy file
+  set(IS_TOPDIR TRUE)
+  cmake_minimum_required(VERSION 2.6.4)
 # project name
-project (dagsolid)
-
-# make the dagsolid lib
-add_library (dagsolid SHARED ../src/DagSolid.cc)
+  project(dagsolid)
 
 # set moab paths
-set(MOAB_INCLUDE ${MOAB_DIR}/include)
-set(MOAB_LIBS ${MOAB_DIR}/lib)
-
+  set(MOAB_INCLUDE ${MOAB_DIR}/include)
+  set(MOAB_LIBS ${MOAB_DIR}/lib)
 # set geant paths
-set(GEANT_INCLUDE ${GEANT_DIR}/include/Geant4/ )
-
-# include files
-include_directories(../include ${GEANT_INCLUDE} ${MOAB_INCLUDE} ${HDF5_INCLUDE})
-
-# set libs
-set(moab_libs ${MOAB_DIR}/lib/libdagmc.so ${MOAB_DIR}/lib/libMOAB.so)
-
-# targets
-set (CMAKE_INSTALL_PREFIX .)
-install(TARGETS dagsolid DESTINATION ${DAGSOLID_DIR}/lib)
+  set(GEANT_INCLUDE ${GEANT_DIR}/include/Geant4/ )
+  include_directories(../include ${GEANT_INCLUDE} ${MOAB_INCLUDE} ${HDF5_INCLUDE})
+# Why the next line?
+  set(moab_libs ${MOAB_DIR}/lib/libdagmc.so ${MOAB_DIR}/lib/libMOAB.so)
+  add_library(dagsolid SHARED DagSolid.cc)
+# Why the next line?
+  set (CMAKE_INSTALL_PREFIX .)
+  install(TARGETS dagsolid DESTINATION ${DAGSOLID_DIR}/lib)
+else ()
+  set(IS_TOPDIR FALSE)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include
+    ${Geant4_INCLUDE_DIRS} ${Moab_INCLUDE_DIRS} ${HDF5_INCLUDE_DIRS}
+  )
+  add_library(dagsolid DagSolid.cc)
+  if (BUILD_SHARED_LIBS)
+    set_target_properties(dagsolid PROPERTIES
+      SOVERSION ${VERSION_MAJOR}.${VERSION_MINOR}
+      VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
+      COMPILE_DEFINITIONS dagsolid_EXPORTS
+    )
+    target_link_libraries(dagsolid
+      ${Moab_MOAB_LIBRARY}
+      ${Moab_dagmc_LIBRARY}
+      ${Geant4_G4geometry_LIBRARY}
+      ${Geant4_G4clhep_LIBRARY}
+      ${Geant4_G4global_LIBRARY}
+    )
+  endif ()
+  install(TARGETS dagsolid DESTINATION Geant4/lib)
+endif ()
 


### PR DESCRIPTION
This adds CMakeLists.txt files from the top down to Geant4/dagsolid/src and adds
the library versioning and dependencies so that share libs build correctly on OS X.
Build on Linux also checked.  Cannot build Windows until moab and cgm are properly
cmakified.

This pulls in the scimake repo at the top; said repo helped to cmakify dagmc.

It can also be built with all dependencies as the Bilder project, dagmcall, which is
obtained and built by doing.

https://svn.code.sf.net/p/bilder/code/dagmcall/trunk dagmcall
cd dagmcall
./mkdagmcall-default.sh
