### PR TITLE
Update uwuw_preproc

### DIFF
--- a/tools/uwuw_preproc
+++ b/tools/uwuw_preproc
@@ -197,52 +197,40 @@ mat_lib - pyne material library instance
 returns mat_dens_list, a zipped pair of density and material name
 """
 def check_matname(tag_values):
-    # loop over tags
+    # loop over tags to check the existence of a 'vacuum' group
+    for tag in tag_values:
+        if ('Vacuum' in tag) or ('vacuum' in tag):
+            tag_values.remove(tag)
     g = 0
     mat_list_matname = []  # list of material names
     mat_list_density = []  # list of density if provided in the group names
-    # loop over the tags in the file
+    # loop over the tags in the file to test the existence of a graveyard
     for tag in tag_values:
-        print tag
-        if 'Graveyard' in tag or 'graveyard' in tag:
+        if ('Graveyard' in tag) or ('graveyard' in tag):
             g = 1
             continue
     # look for mat, this id's material in group name
-        if tag[0:3] == 'mat':
+        if (tag[0:3] == 'mat'):
             # split on the basis of "/" being delimiter and split colons from
             # name
-            if '/' in tag:
-                mat_name = tag.split('/')
-                if ':' not in mat_name[0]:
-                    raise Exception("Could not find group name in appropriate format; ':' is absent in %s" % tag)
-                # list of material name only
-                matname = mat_name[0].split(':')
-                if matname[1] == '':
-                    raise Exception("Could not find group name in appropriate format; material name in blank  %s" % tag)
-                if mat_name[1] == '':
-                    raise Exception("Could not find group name in appropriate format; extra \'/\' in %s" % tag)
-                if ':' not in mat_name[1]:
-                    raise Exception("Could not find group name in appropriate format; ':' is absent after the '/' in %s" % tag)
-                matdensity = mat_name[1].split(':')
-                try:
-                    matdensity_test = float(matdensity[1])
-                except:
-                    raise Exception("Could not find density in appropriate format!; density is not a float in %s" % tag)
-                mat_list_density.append(matdensity[1])
+            if ('/' in tag):
+                splitted_group_name = mat_dens_split(tag)
             # otherwise we have only "mat:"
-            elif ':' in tag:
+            elif (':' in tag):
                 splitted_group_name = mat_split(tag)
             else:
                 raise Exception(
                     "Couldn\'t find group name in appropriate format; ': is absent' in  %s" % tag)
             mat_list_matname.append(splitted_group_name['material'])
             mat_list_density.append(splitted_group_name['density'])
-    if g == 0:
-        raise Exception("Graveyard group is missing! You must have a graveyard")
+    if (g == 0):
+        raise Exception(
+            "Graveyard group is missing! You must have a graveyard")
     mat_dens_list = zip(mat_list_matname, mat_list_density)
     # error conditions, no tags found
-    if len(mat_dens_list) == 0:
-        raise Exception("No material group names found, you must have materials")
+    if (len(mat_dens_list) == 0):
+        raise Exception(
+            "No material group names found, you must have materials")
 
     return mat_dens_list
 


### PR DESCRIPTION
Andy, I discovered a problem with check_matname function which you edited!. my original one is tied to other functions that splits the group name and extracts material name and density; mat_dens_split & mat_split, when you edited it you added some "Exceptions" - which I think already done within the splitting process- but you kept the references to the original splitting functions as is which give and error when trying to run

I created a model with just one volume with tag "mat:Nitrogen/rho:-3" and with the edited i propose her the script worked fine. Could you please check this change and tell me if the problem you said is resolved or not. Any way I'll go over the script to make sure that every thing is OK
